### PR TITLE
Fix loki volume mount

### DIFF
--- a/run-lgtm.ps1
+++ b/run-lgtm.ps1
@@ -32,7 +32,7 @@ $runCommand = @(
     '-ti',
     '-v', "${path}/container/grafana:/data/grafana"
     '-v', "${path}/container/prometheus:/data/prometheus"
-    '-v', "${path}/loki:/loki"
+    '-v', "${path}/container/loki:/data/loki"
     '-e', "GF_PATHS_DATA=/data/grafana"
     $image
 )


### PR DESCRIPTION
This command currently fails with `Error: statfs /mnt/c/Users/<username>/loki: no such file or directory`.

In fact, the directory is created on line 20, but it is at the path `${path}/container/loki`, not `${path}/loki`.

This change matches the other directories, and also brings this script in line with the bash equivalent `run-lgtm.sh`.